### PR TITLE
Fixes issue where race condition could cause segfault

### DIFF
--- a/src/price/provider/abstract_provider.cpp
+++ b/src/price/provider/abstract_provider.cpp
@@ -74,7 +74,7 @@ void AbstractProvider::CreateConnection()
     try
     {
         ssl_client_ = tunnel_connector_.Connect(GetProtocolOptions().GetHeartbeatInterval() * 2);
-        InitiatePriceServerConnection(*ssl_client_);
+        InitiatePriceServerConnection(ssl_client_);
         ssl_client_->Close();
     }
     catch(std::exception &e)

--- a/src/price/provider/abstract_provider.h
+++ b/src/price/provider/abstract_provider.h
@@ -48,7 +48,7 @@ private:
 
     UserInfo* user_info_;
     TunnelConnector tunnel_connector_;
-    std::unique_ptr<SSLClient> ssl_client_;
+    std::shared_ptr<SSLClient> ssl_client_;
 
     std::atomic<RunState> run_state_ = RunState::INITIAL;
     CountdownLatch latch;
@@ -74,7 +74,7 @@ protected:
 
     void SetProviderStatus(Status status, std::string text);
 
-    virtual void InitiatePriceServerConnection(SSLClient& ssl_client_) = 0;
+    virtual void InitiatePriceServerConnection(std::shared_ptr<SSLClient> ssl_client_) = 0;
 
     bool IsRunning();
 

--- a/src/price/provider/pixie/pixie_provider.h
+++ b/src/price/provider/pixie/pixie_provider.h
@@ -81,16 +81,16 @@ private:
 
     void Login(InputStream& in, OutputStream& out, const PixieProtocolOptions& options, SSLClient& ssl_client);
     void WriteProtocolSignature(OutputStream& out, std::string url);
-    WelcomeMessage ReadWelcomeMessage(InputStream& in, SSLClient& ssl_client);
-    GrantMessage ReadGrantMessage(InputStream& in, SSLClient& ssl_client);
-    ByteBuffer ReadMessageFrame(InputStream& in, SSLClient& ssl_client);
+    WelcomeMessage ReadWelcomeMessage(InputStream& in);
+    GrantMessage ReadGrantMessage(InputStream& in);
+    ByteBuffer ReadMessageFrame(InputStream& in);
     void CheckType(ByteBuffer& message_frame, const unsigned char& expected_type);
-    void MainLoop(InputStream& in, OutputStream& out, SSLClient& ssl_client);
-    void HandleNextMessage(InputStream& in, SSLClient& ssl_client);
+    void MainLoop(std::shared_ptr<SSLClient> ssl_client);
+    void HandleNextMessage(InputStream& in);
     void HandlePriceSync(PriceSync& price_sync);
     void OnDataDictionary(DataDictionaryMessage& dict_message);
-    void StartWriter(OutputStream& out, SSLClient& ssl_client);
-    void HandleAcksAndSendSubscriptionSyncsAndHeartbeats(OutputStream& out, int thread_num);
+    void StartWriter(std::shared_ptr<SSLClient> ssl_client);
+    void HandleAcksAndSendSubscriptionSyncsAndHeartbeats(std::shared_ptr<SSLClient> ssl_client, int thread_num);
     std::unique_ptr<AckData> PollNextAck();
     void PeriodicallyCheckSubscriptions(OutputStream& out);
     void CheckAndSendSubscriptions(OutputStream& out);
@@ -98,7 +98,7 @@ private:
     void OnConnectionError();
 
 protected:
-    void InitiatePriceServerConnection(SSLClient& ssl_client) override;
+    void InitiatePriceServerConnection(std::shared_ptr<SSLClient> ssl_client) override;
 
 public:
     explicit PixieProvider(UserInfo *user_info);

--- a/src/tools/network/tunnel_connector.cpp
+++ b/src/tools/network/tunnel_connector.cpp
@@ -38,12 +38,12 @@ TunnelConnector::TunnelConnector(UserInfo& user_info, std::string service) : use
     }
 }
 
-std::unique_ptr<SSLClient> TunnelConnector::Connect(std::chrono::milliseconds read_timeout)
+std::shared_ptr<SSLClient> TunnelConnector::Connect(std::chrono::milliseconds read_timeout)
 {
     try
     {
         Log->info("Connecting to {}:{} with read timeout {}ms", user_info_.GetHost(), user_info_.GetPort(), read_timeout.count());
-        std::unique_ptr<SSLClient> ssl_client = std::make_unique<OpenSSLClient>(user_info_.GetHost(), user_info_.GetPort(), read_timeout);
+        std::shared_ptr<SSLClient> ssl_client = std::make_shared<OpenSSLClient>(user_info_.GetHost(), user_info_.GetPort(), read_timeout);
         ssl_client->Start();
 
         if (user_info_.IsTunnelRequired())

--- a/src/tools/network/tunnel_connector.h
+++ b/src/tools/network/tunnel_connector.h
@@ -46,7 +46,7 @@ private:
 
 public:
     TunnelConnector(UserInfo& user_info, std::string service);
-    std::unique_ptr<SSLClient> Connect(std::chrono::milliseconds read_timeout);
+    std::shared_ptr<SSLClient> Connect(std::chrono::milliseconds read_timeout);
 };
 
 


### PR DESCRIPTION
This can occur when reader thread had failed (due to socket disconnect) and writer thread attempts to write to output stream of ssl_client that has been freed.